### PR TITLE
Fix example : use udp instead of tcp for port 7777

### DIFF
--- a/satisfactory/README.md
+++ b/satisfactory/README.md
@@ -11,7 +11,7 @@ docker create -it --restart always \
   --name satisfactory-server \
   -p 15777:15777/udp \
   -p 15000:15000/udp \
-  -p 7777:7777/tcp \
+  -p 7777:7777/udp \
   ipshosting/game-satisfactory:v2
   
 # Start the server


### PR DESCRIPTION
The example exposes port 7777 as TCP but further down in the README as well as in the Dockerfile  it is UDP port 7777 that is exposed. Indeed, the correct port to expose is UDP 7777.