### PR TITLE
Add SCPSL script functionality to write envvar overrides to config_gameplay.txt

### DIFF
--- a/scpsl/entrypoint.sh
+++ b/scpsl/entrypoint.sh
@@ -43,12 +43,12 @@ function update() {
 	fi
 }
 
+CONFIG_FILE="/home/ips-hosting/.config/SCP Secret Laboratory/config/${GAME_PORT:-7777}/config_gameplay.txt"
+
 # Function to update config
 function update_config() {
 	local key=$1
 	local value=$2
-
-	CONFIG_FILE="/home/ips-hosting/.config/SCP Secret Laboratory/config/${GAME_PORT:-7777}/config_gameplay.txt"
 
 	# Convert key to lowercase
 	key=$(echo "$key" | tr '[:upper:]' '[:lower:]')
@@ -70,8 +70,17 @@ function start() {
 	ln -svf ".config/SCP Secret Laboratory/ServerLogs/${GAME_PORT:-7777}" /home/ips-hosting/ServerLogs
 	ln -svf ".config/SCP Secret Laboratory/LocalAdminLogs/${GAME_PORT:-7777}" /home/ips-hosting/LocalAdminLogs
 
-	# Ensure .config folder exists: https://github.com/northwood-studios/LocalAdmin-V2/issues/52
-	mkdir -vp .config
+	local start_command="./LocalAdmin ${GAME_PORT:-7777} --printStd --noSetCursor --config /home/ips-hosting/localadmin_config.txt --useDefault --logLengthLimit ${LOG_LENGTH_LIMIT:-1G} --gameLogs '/home/ips-hosting/.config/SCP Secret Laboratory/ServerLogs/${GAME_PORT:-7777}' --logs '/home/ips-hosting/.config/SCP Secret Laboratory/LocalAdminLogs/${GAME_PORT:-7777}'"
+
+ 	if [! -f "$CONFIG_FILE"]; then
+  		echo "Error: config_gameplay.txt does not exist at $CONFIG_FILE. Running server for 30s to generate config..."
+		
+  		# Ensure .config folder exists: https://github.com/northwood-studios/LocalAdmin-V2/issues/52
+		mkdir -vp .config
+
+  		# Run server long enough to generate config
+    		timeout 30s eval "$start_command"
+  	fi
 
 	# Loop through all config environment variables and add to config_gameplay.txt
 	for var in $(compgen -e); do
@@ -90,7 +99,6 @@ function start() {
     		fi
 	done
 
-	local start_command="./LocalAdmin ${GAME_PORT:-7777} --printStd --noSetCursor --config /home/ips-hosting/localadmin_config.txt --useDefault --logLengthLimit ${LOG_LENGTH_LIMIT:-1G} --gameLogs '/home/ips-hosting/.config/SCP Secret Laboratory/ServerLogs/${GAME_PORT:-7777}' --logs '/home/ips-hosting/.config/SCP Secret Laboratory/LocalAdminLogs/${GAME_PORT:-7777}'"
 	echo "$start_command"
 	eval "$start_command"
 }

--- a/scpsl/entrypoint.sh
+++ b/scpsl/entrypoint.sh
@@ -55,11 +55,11 @@ function update_config() {
 
 	# Check if the key exists in the file
 	if grep -q "^$key:" "$CONFIG_FILE"; then
-	# Key exists, update it
-	sed -i "s/^$key:.*/$key: $value/" "$CONFIG_FILE"
+		# Key exists, update it
+		sed -i "s/^$key:.*/$key: $value/" "$CONFIG_FILE"
 	else
-	# Key doesn't exist, add it
-	echo "$key: $value" >> "$CONFIG_FILE"
+		# Key doesn't exist, add it
+		echo "$key: $value" >> "$CONFIG_FILE"
 	fi
 }
 
@@ -72,15 +72,15 @@ function start() {
 
 	local start_command="./LocalAdmin ${GAME_PORT:-7777} --printStd --noSetCursor --config /home/ips-hosting/localadmin_config.txt --useDefault --logLengthLimit ${LOG_LENGTH_LIMIT:-1G} --gameLogs '/home/ips-hosting/.config/SCP Secret Laboratory/ServerLogs/${GAME_PORT:-7777}' --logs '/home/ips-hosting/.config/SCP Secret Laboratory/LocalAdminLogs/${GAME_PORT:-7777}'"
 
- 	if [! -f "$CONFIG_FILE"]; then
-  		echo "Error: config_gameplay.txt does not exist at $CONFIG_FILE. Running server for 30s to generate config..."
-		
-  		# Ensure .config folder exists: https://github.com/northwood-studios/LocalAdmin-V2/issues/52
+ 	if [ ! -f "$CONFIG_FILE" ]; then
+		echo "Error: config_gameplay.txt does not exist at $CONFIG_FILE. Running server for 30s to generate config..."
+
+		# Ensure .config folder exists: https://github.com/northwood-studios/LocalAdmin-V2/issues/52
 		mkdir -vp .config
 
-  		# Run server long enough to generate config
-    		timeout 30s eval "$start_command"
-  	fi
+		# Run server long enough to generate config
+		echo "yes" | eval timeout 30s "$start_command" || true
+	fi
 
 	# Loop through all config environment variables and add to config_gameplay.txt
 	for var in $(compgen -e); do
@@ -93,10 +93,10 @@ function start() {
 			key=${var_lower#config_}
 			# Get the value of the variable
 			value=${!var}
-		
+
 			# Update the config file
 			update_config "$key" "$value"
-    		fi
+		fi
 	done
 
 	echo "$start_command"


### PR DESCRIPTION
This allows you to specify envvars prefixed with `config_` which will update the config_gameplay.txt file on startup. Existing properties will be modified, otherwise the property will be appended to the file.

Such as:

```bash
# -> server_name: My New Server Name
export config_server_name="My New Server Name"

# -> use_native_sockets: true
export CONFIG_USE_NATIVE_SOCKETS=true

 # -> my_new_property: 3.66
export cOnFiG_my_new_property=3.66

docker create -it --restart always \
  --name scpsl-server \
  -p 7777:7777/udp \
  -p 7777:7777/tcp \
  ipshosting/game-scpsl:v2
```